### PR TITLE
use pth to load the import hook automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,21 @@ You can use `mingshe --compile ./main.she` to generate python file.
 
 ### As a module
 
-If you want to use MíngShé's files as a module that be imported, you can add `mingshe.importlib.install_meta(".she")` before `import`. Then you can import module that written by MíngShé in python code or MíngShé code.
+You can directly import MíngShé script as a module, as long as the script name ends with `.she`.
+
+Example:
+
+```python
+# lib.she
+def digit_sum(s: str) -> int:
+    return s |> map(int, ?) |> sum
+```
+
+```python
+# main.py
+from lib import digit_sum
+print(digit_sum('123456'))
+```
 
 ## Extended syntax
 

--- a/aaa_mingshe.pth
+++ b/aaa_mingshe.pth
@@ -1,0 +1,1 @@
+import mingshe.importlib;mingshe.importlib.install_meta(".she")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,8 @@ packages = [
   {include = "mingshe"},
 ]
 
+include = ["aaa_mingshe.pth"]
+
 [tool.poetry.dependencies]
 python = "^3.9"
 
@@ -29,5 +31,5 @@ pytest = "^5.4.3"
 mingshe = 'mingshe.commands:main'
 
 [build-system]
-build-backend = "poetry.masonry.api"
-requires = ["poetry>=0.12"]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
1. Put a pth file in the top level, it will be copied into the package. Use the prefix `aaa_` so that it will be loaded as early as possible.
2. Update README. with an example.
3. Update the build-backend to Poetry 1.0 style, you may need to update your repo template as well.